### PR TITLE
fix: increase lifecycle for error blocks

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -142,7 +142,7 @@ const x8 = () => {
   lightCameraNear: 3,
   lightCameraFar: 16,
   errorBlock: null,
-  errorBlockMaxLifeCycle: 4,
+  errorBlockMaxLifeCycle: 6,
   minSpawnedBlocksForTheErrorBlock: Zw - 2,
   bgColor1: "#ffffff",
   bgColor2: "#d0d0d0",

--- a/lib/scripts/core/properties.ts
+++ b/lib/scripts/core/properties.ts
@@ -49,7 +49,7 @@ export const propertiesInitialState: PropertiesType = {
 	lightCameraNear: 3,
 	lightCameraFar: 16,
 	errorBlock: null,
-	errorBlockMaxLifeCycle: 4,
+	errorBlockMaxLifeCycle: 6,
 	minSpawnedBlocksForTheErrorBlock: maxFreeBlocksCount - 2,
 	bgColor1: '#ffffff',
 	bgColor2: '#d0d0d0',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tari-project/tari-tower",
-	"version": "0.0.31",
+	"version": "0.0.32",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tari-project/tari-tower",
-			"version": "0.0.31",
+			"version": "0.0.32",
 			"license": "ISC",
 			"devDependencies": {
 				"@eslint/js": "^9.19.0",


### PR DESCRIPTION
### Description
Increase max life cycle for error block `errorBlockMaxLifeCycle` from 4 to 6. This could fix or at least make it less common bug in which animation keeps going after changing state to stop.

### Motivation
While debugging I noticed that this value sometimes tends to cross it's max limit:
```
 2025-04-29 11:58:23.215903113 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 120/4"
 ```

 now combined with changing state to `fail` and `stop` right after and we get stuck animation:
 ```
 2025-04-29 11:58:20.322953939 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 119/4"
 2025-04-29 11:58:23.215903113 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 120/4"
 2025-04-29 11:58:24.238758012 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: fail "
 2025-04-29 11:58:26.177801048 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 121/4"
 2025-04-29 11:58:26.811722080 INFO  v0.9.906 -  "Mining stopping..."
 2025-04-29 11:58:27.141984816 INFO  v0.9.906 -  "Mining stopped."
 2025-04-29 11:58:27.143089610 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:29.084580884 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 122/4"
 2025-04-29 11:58:29.110880661 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 1/15: status=free"
 2025-04-29 11:58:29.111667107 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:31.113732074 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 2/15: status=free"
 2025-04-29 11:58:31.114817684 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:31.932029663 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 123/4"
 2025-04-29 11:58:33.115489123 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 3/15: status=free"
 2025-04-29 11:58:33.116258859 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:34.913348486 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 124/4"
 2025-04-29 11:58:35.115552085 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 4/15: status=free"
 2025-04-29 11:58:35.116213471 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:37.117395196 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 5/15: status=free"
 2025-04-29 11:58:37.118651872 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:37.868875435 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 125/4"
 2025-04-29 11:58:39.118908631 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 6/15: status=free"
 2025-04-29 11:58:39.120159059 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:40.905493501 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 126/4"
 2025-04-29 11:58:41.120083965 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 7/15: status=free"
 2025-04-29 11:58:41.120958945 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:43.124269858 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 8/15: status=free"
 2025-04-29 11:58:43.125188054 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:43.827363584 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 127/4"
 2025-04-29 11:58:45.123557862 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 9/15: status=free"
 2025-04-29 11:58:45.124734018 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:46.631182115 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 128/4"
 2025-04-29 11:58:47.123819986 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 10/15: status=free"
 2025-04-29 11:58:47.125391997 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:49.125194072 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 11/15: status=free"
 2025-04-29 11:58:49.125998298 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:49.507747042 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 129/4"
 2025-04-29 11:58:51.126172135 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 12/15: status=free"
 2025-04-29 11:58:51.127246049 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:52.484373517 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 130/4"
 2025-04-29 11:58:53.128853538 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 13/15: status=free"
 2025-04-29 11:58:53.130102445 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:55.128789176 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 14/15: status=free"
 2025-04-29 11:58:55.129777214 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:55.417922965 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 131/4"
 2025-04-29 11:58:57.130014129 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop attempt 15/15: status=free"
 2025-04-29 11:58:57.130996603 INFO  v0.9.906 -  "tari-tower info | " "stateManager.set - id: stop "
 2025-04-29 11:58:58.276819497 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 132/4"
 2025-04-29 11:58:59.133066594 INFO  v0.9.906 -  "tari-tower info | " "Animation Stop failed after 15 retries: status=free"
 2025-04-29 11:59:01.205905605 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 133/4"
 2025-04-29 11:59:04.082286044 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 134/4"
 2025-04-29 11:59:06.977689953 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 135/4"
 2025-04-29 11:59:09.937059385 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 136/4"
 2025-04-29 11:59:12.772189712 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 137/4"
 ```

By increasing the max lifecycle we give library more time to reset it's `lifecycle` for error block preventing it from exceeding the limit.

### Testing
Check logs for universe-web (or check console in dev mode) and verify that lifecycle reached value 4 or even 5 but it hasn't exceed new limit:
```
 2025-04-29 16:08:22.392438073 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: false, lifecycle: 4/6"
 2025-04-29 16:08:25.906662018 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 5/6"
 2025-04-29 16:08:42.399014720 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: false, lifecycle: 4/6"
 2025-04-29 16:08:45.036305164 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 5/6"
 2025-04-29 16:09:01.797708410 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: false, lifecycle: 4/6"
 2025-04-29 16:09:05.456511135 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 5/6"
 2025-04-29 16:09:28.016331709 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: false, lifecycle: 4/6"
 2025-04-29 16:09:31.556399864 INFO  v0.9.906 -  "tari-tower info | " "long block in updateAfterCycle | " "falling: true, lifecycle: 5/6"
 ```
 Also try to stop animation right after losing or wining block to check if animation is still going